### PR TITLE
update for OSX's System_Integrity_Protection

### DIFF
--- a/062-mocha/readme.md
+++ b/062-mocha/readme.md
@@ -1,3 +1,20 @@
 062 Mocha
 
 For explanatory notes, video file, tool version and other info, please refer to the [screencast link](http://build-podcast.com/mocha/)
+
+Note for selenium/browser section on OSX, El Capitan:  
+- chromedriver, and 
+- selenium-driver-standalone  
+may not be able to be installed in  `/usr/bin` , even when logged in as root, using sudo  
+  due to the new System_Integrity_Protection (there *is* a way around it, but..)   
+
+install instead in `usr/local/bin`.  
+Be sure to switch to this directory in the terminal tab you use to run selenium server.
+
+For more info see: http://forums.appleinsider.com/discussion/189702/cant-copy-file-to-usr-bin-even-when-logged-in-as-root
+
+There is also an option to `npm install selenium-server-standalone-jar --save-dev`  
+(see: https://github.com/adamhooper/selenium-server-standalone-jar) 
+
+Also if you get an error message starting the server, check this link:  
+http://stackoverflow.com/questions/5883450/selenium-invalid-already-running-error-when-starting-server 


### PR DESCRIPTION
I did not find repo for the show notes/instructions/transcript for this episode, so I PR'd here..

One can no longer paste files in /usr/bin if running OSX, even with sudo, as root.
(well, you can, but it involves rebooting, turning system protection off, etc. not straightforward, or ideal..)

Above are solutions I have found.

It took me hours to find this information; perhaps it'll help someone else.

-----

  *(
in fact from the video and internet searches, it was not obvious where I was even supposed to put selenium-driver-standalone. 
It worked when I put it in the root of the repo, but I saw you did not put it there, and it seemed like an odd location to keep it. 
Most dependancies/external software is in node_modules/package-control. 
I think you put it on Desktop, but I really did not want it to permanently live there.. 
I'm newish to mac, so it was not obvious to me where it should live, and selenium websites didn't mention where it should go either ! 
Good news, I have a much better understanding of how the file system works..
I think if I use selenium extensively in my app, I'll instead npm install selenium-server-standalone-jar --save-dev 
  )*