### PR TITLE
typo on page: https://build-podcast.com/travisci/

### DIFF
--- a/032-travisci/readme.md
+++ b/032-travisci/readme.md
@@ -1,3 +1,19 @@
 #032 Travis CI
 
 For explanatory notes, video file, tool version and other info, please refer to the [screencast link](http://build-podcast.com/travisci/)
+
+----
+
+On: 
+
+   https://build-podcast.com/travisci/
+
+Reads: 
+
+    "Travis CI is a hosted continuous integration platform `fre` for open source."
+
+Should Read: (Maybe?) 
+
+    "Travis CI is a hosted continuous integration platform, `free` for open source (projects)."
+----
+    Travis CI is a hosted continuous integration platform, free for open source projects.


### PR DESCRIPTION
(I do not see an issues tab, and I don't see a github page for the actual error page)
So, while I do not expect this PR to be merged, I wanted to fix a typo on:

Reads:
Travis CI is a hosted continuous integration platform fre for open source.

Should Read: (Maybe?)
Travis CI is a hosted continuous integration platform, free for open source projects.

Thank You, 
Your podcasts are excellent !
I enjoy your fantastic progressions when showing [the technology] features.
I also enjoy your curated list of links.
Well Spoken: excellent dialog/script, wonderful clear voice. Clear, concise, thorough. :-)